### PR TITLE
Remove & aka \x26 from ReplaceHexadecimalSymbols

### DIFF
--- a/src/CsvHelper.Excel/ExcelSerializer.cs
+++ b/src/CsvHelper.Excel/ExcelSerializer.cs
@@ -124,7 +124,7 @@ namespace CsvHelper.Excel
         protected static string ReplaceHexadecimalSymbols(string text)
         {
             if (String.IsNullOrEmpty(text)) return text;
-            return Regex.Replace(text, "[\x00-\x08\x0B\x0C\x0E-\x1F\x26]", String.Empty, RegexOptions.Compiled);
+            return Regex.Replace(text, "[\x00-\x08\x0B\x0C\x0E-\x1F]", String.Empty, RegexOptions.Compiled);
         }
 
         /// <summary>


### PR DESCRIPTION
I have had an issue reported by a client on a system where we are exporting an Excel file via CsvHelper and & characters are being stripped from text in cells.. 


I am not sure why these specific characters are matched:

Here is the matching regex you are using:
https://regex101.com/r/wtLLDj/1

[\x00-\x08\x0B\x0C\x0E-\x1F\x26]
\x00-\x08 a single character in the range between  (ASCII 0) and  (ASCII 8) (case sensitive)
\x0B matches the character  with index B16 (1110 or 138) literally (case sensitive)
\x0C matches the character  with index C16 (1210 or 148) literally (case sensitive)
\x0E-\x1F a single character in the range between  (ASCII 14) and  (ASCII 31) (case sensitive)
\x26 matches the character &amp; with index 2616 (3810 or 468) literally (case sensitive)

I tried a simple replace of & with "& amp;" (space added for github comments) but this came through as "& amp;" in Excel, so I just dropped the \26 from the regex and this seemed to be working fine - the & exported correctly. 
Without context of why these specific characters are stripped, this will do for now!

PS: I had to branch from before the conversion to project.json as I couldn't figure out how to build the project (oops!) and I have very limited time to resolve this issue right now.

