### PR TITLE
Upgraded ClosedXML and DocumentFormat.OpenXml for net40

### DIFF
--- a/src/CsvHelper.Excel.Specs/CsvHelper.Excel.Specs.csproj
+++ b/src/CsvHelper.Excel.Specs/CsvHelper.Excel.Specs.csproj
@@ -1,11 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.89.0" />
-    <PackageReference Include="CsvHelper" Version="2.16.3" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170914-09" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.5.0-preview-20170914-09" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />

--- a/src/CsvHelper.Excel.Specs/CsvHelper.Excel.Specs.csproj
+++ b/src/CsvHelper.Excel.Specs/CsvHelper.Excel.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFrameworks>net46</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170914-09" />

--- a/src/CsvHelper.Excel/CsvHelper.Excel.csproj
+++ b/src/CsvHelper.Excel/CsvHelper.Excel.csproj
@@ -13,24 +13,20 @@
     <PackageProjectUrl>https://github.com/christophano/CsvHelper.Excel</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/christophano/CsvHelper.Excel/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <Reference Include="System.Data" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="ClosedXML" Version="0.94.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <Reference Include="System.Data" />
     <Reference Include="System" />
+    <PackageReference Include="ClosedXML" Version="0.87.1" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="2.16.3" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <PackageReference Include="ClosedXML" Version="0.87.1" />    
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' ">
-    <PackageReference Include="ClosedXML" Version="0.94.2" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
   </ItemGroup>
 </Project>

--- a/src/CsvHelper.Excel/CsvHelper.Excel.csproj
+++ b/src/CsvHelper.Excel/CsvHelper.Excel.csproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <Description>An implementation of ICsvParser and ICsvSerializer from CsvHelper that reads and writes using the ClosedXml library.</Description>
     <AssemblyTitle>CsvHelper for Excel</AssemblyTitle>
-    <VersionPrefix>1.0.6</VersionPrefix>
+    <VersionPrefix>1.0.7</VersionPrefix>
     <Authors>Chris Rodgers</Authors>
-    <TargetFrameworks>net40;net35</TargetFrameworks>
+    <TargetFrameworks>net40;net35;</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>CsvHelper.Excel</AssemblyName>
     <OutputType>Library</OutputType>
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/christophano/CsvHelper.Excel</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/christophano/CsvHelper.Excel/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' ">
     <Reference Include="System.Data" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
@@ -23,8 +23,14 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.87.1" />
     <PackageReference Include="CsvHelper" Version="2.16.3" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
+    <PackageReference Include="ClosedXML" Version="0.87.1" />    
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' ">
+    <PackageReference Include="ClosedXML" Version="0.94.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
   </ItemGroup>
 </Project>

--- a/src/CsvHelper.Excel/ExcelSerializer.cs
+++ b/src/CsvHelper.Excel/ExcelSerializer.cs
@@ -183,7 +183,9 @@ namespace CsvHelper.Excel
             if (disposed) return;
             if (disposing)
             {
+#if !NET40
                 if (disposeWorksheet) range.Worksheet.Dispose();
+#endif
                 if (disposeWorkbook)
                 {
                     Workbook.SaveAs(path);


### PR DESCRIPTION
Due to a conflict with OpenXml I've upgraded ClosedXML and DocumentFormat.OpenXml for net40. Seems to fix the issue.

Running on .net core mvc with .net framwork 461.

`
Could not load file or assembly 'Document.OpenXml, Version=2.5.5631.0
`
